### PR TITLE
Bounce detection and the swapping algorithm (with format fixed)

### DIFF
--- a/src/main/java/origami/crease_pattern/worker/HierarchyList_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/HierarchyList_Worker.java
@@ -3,6 +3,7 @@ package origami.crease_pattern.worker;
 import origami_editor.editor.databinding.FoldedFigureModel;
 import origami.crease_pattern.element.LineColor;
 import origami.folding.HierarchyList;
+import origami.folding.util.BounceDetector;
 import origami.folding.util.EquivalenceCondition;
 import origami.folding.element.SubFace;
 import origami.crease_pattern.element.LineSegment;
@@ -53,6 +54,8 @@ public class HierarchyList_Worker {
     int makesuu0no_menno_amount = 0;//Number of faces that can be ranked without any other faces on top
     int makesuu1ijyouno_menno_amount = 0;//Number of faces that can only be ranked if there is one or more other faces on top
     private int top_face_id_ga_maketa_kazu_goukei_without_rated_face = 0;
+
+    BounceDetector bounceDetector = new BounceDetector();
 
     public HierarchyList_Worker(BulletinBoard bb0) {
         bb = bb0;
@@ -1020,17 +1023,15 @@ public class HierarchyList_Worker {
         }
         //The overlapping state of the surfaces is changed in order from the one with the largest id number of the SubFace.
         subfaceId = ss;
-        for (int i = ss; i >= 1; i--) {
-            if (isusumu == 0) {
-                isusumu = s[i].next(s[i].getFaceIdCount());
-                subfaceId = i;
-            }
-
+        for (int i = ss; i >= 1 && isusumu == 0; i--) {
+            isusumu = s[i].next(s[i].getFaceIdCount());
+            subfaceId = i;
         }
         if (isusumu == 0) {
-            subfaceId = 0;
+            return 0;
         }
 
+        bounceDetector.recordLow(subfaceId);
         return subfaceId;
     }
 
@@ -1062,6 +1063,8 @@ public class HierarchyList_Worker {
             Sid = next(ms - 1);
             bb.rewrite(9, "susumu(" + ms + "-1 = )" + Sid);
 
+            bounceDetector.checkAndSwap(s);
+
             if (Thread.interrupted()) throw new InterruptedException();
         }
         return 0;//There is no possible overlapping state
@@ -1085,6 +1088,7 @@ public class HierarchyList_Worker {
 
 
             if (kks == 0) {//kks == 0 means that there is no permutation that can overlap
+                bounceDetector.recordHigh(ss);
                 return ss;
             }
             s[ss].hierarchyList_at_subFace_wo_input(hierarchyList);//Enter the top and bottom information of the ss th SubFace in hierarchyList.

--- a/src/main/java/origami/folding/HierarchyList.java
+++ b/src/main/java/origami/folding/HierarchyList.java
@@ -85,8 +85,8 @@ public class HierarchyList {//This class is used to record and utilize the hiera
     }
 
     public Iterable<EquivalenceCondition> getEquivalenceConditions(int a) {
-		return tLMap.get(a);
-	}
+        return tLMap.get(a);
+    }
 
     // Add equivalence condition. When there are two adjacent faces im1 and im2 as the boundary of the bar ib, when the folding is estimated
     // The surface im located at the position where it overlaps a part of the bar ib is not sandwiched between the surface im1 and the surface im2 in the vertical direction. From this

--- a/src/main/java/origami/folding/util/BounceDetector.java
+++ b/src/main/java/origami/folding/util/BounceDetector.java
@@ -1,0 +1,112 @@
+package origami.folding.util;
+
+import java.util.*;
+
+import origami.folding.element.SubFace;
+
+/**
+ * Author: Mu-Tsun Tsai
+ * 
+ * The original Orihime algorithm chooses an initial SubFace ordering to perform
+ * the exhaustive search, but it is very commonly the case that the ordering is
+ * not optimal, leading to a phenomenon I called "bouncing", where the search
+ * hits a dead-end at a certain depth (H) and have to return to another certain
+ * depth (L) repeatedly. This suggests that SubFace H is more "relevant" to
+ * those SubFaces before L, so swapping H and L typically leads to a much faster
+ * search.
+ * 
+ * This BounceDetector class detects the bouncing phenomenon based on some
+ * sensitivity constants and makes the swap when it detects one. A direct
+ * swapping turns out to be the best; I've tried rotation but it's not really
+ * helping.
+ * 
+ * Although this technique in general greatly shortens the runtime for any
+ * model, in some cases it takes a while to detect some less obvious or deeply
+ * buried bouncing. To improve those will take a greater understanding of the
+ * Orihime algorithm.
+ */
+public class BounceDetector {
+
+    private static final int threshold = 3;
+    private static final int target = 6;
+
+    private Map<Integer, Integer> high = new HashMap<Integer, Integer>();
+    private Map<Integer, Integer> low = new HashMap<Integer, Integer>();
+    private List<Integer> highMatch = new ArrayList<>();
+    private List<Integer> lowMatch = new ArrayList<>();
+
+    // To prevent back-and-forth swapping
+    private int lastH = 0, lastL = 0;
+
+    public BounceDetector() {
+        reset();
+    }
+
+    /** Records a high end. */
+    public void recordHigh(int value) {
+        if (add(value, high) == threshold) {
+            highMatch.add(value);
+        }
+    }
+
+    /** Records a low end. */
+    public void recordLow(int value) {
+        if (add(value, low) == threshold) {
+            lowMatch.add(value);
+        }
+    }
+
+    /** Performs the swap if bouncing is detected. */
+    public void checkAndSwap(SubFace[] s) {
+        // Previously it was required that the difference is greater than 1,
+        // but it turns out that it is not necessary.
+        int max = 0;
+        int H = 0, L = 0;
+
+        // Find the best matching
+        for (int h : highMatch) {
+            for (int l : lowMatch) {
+                int diff = h - l;
+                int score = Math.min(high.get(h), low.get(l)) / threshold + diff;
+                if (score > target && diff > max && (h != lastH || l != lastL)) {
+                    H = h;
+                    L = l;
+                    max = diff;
+                }
+            }
+        }
+
+        if (H != 0) {
+            // Perform swap
+            System.out.println("Swap " + H + " with " + L);
+            SubFace temp = s[H];
+            s[H] = s[L];
+            s[L] = temp;
+
+            // Record
+            lastH = H;
+            lastL = L;
+
+            // Finally, reset all data
+            reset();
+        }
+    }
+
+    /** Resets all data. */
+    private void reset() {
+        high.clear();
+        low.clear();
+        highMatch.clear();
+        lowMatch.clear();
+    }
+
+    /** Adds a value into a given record and returns the current count. */
+    private int add(int value, Map<Integer, Integer> record) {
+        int count = 1;
+        if (record.containsKey(value)) {
+            count += record.get(value);
+        }
+        record.put(value, count);
+        return count;
+    }
+}


### PR DESCRIPTION
The original Orihime algorithm chooses an initial SubFace ordering to perform the exhaustive search, but it is very commonly the case that the ordering is not optimal, leading to a phenomenon I called "bouncing", where the search hits a dead-end at a certain depth (H) and have to return to another certain depth (L) repeatedly. This suggests that SubFace H is more "relevant" to those SubFaces before L, so swapping H and L typically leads to a much faster search (in some cases 100x faster).

This BounceDetector class detects the bouncing phenomenon based on some sensitivity constants and makes the swap when it detects one.