### PR TITLE
Performance improvement for super-complex CP

### DIFF
--- a/src/main/java/origami/data/listMatrix/PseudoListMatrix.java
+++ b/src/main/java/origami/data/listMatrix/PseudoListMatrix.java
@@ -15,6 +15,9 @@ import java.util.*;
  * need to check that the returned values are really in List[i][j], this class
  * is excellent in memory efficiency (it uses space O(n) instead of O(n^2))
  * while remains fast in iterating over the list.
+ * 
+ * Even better, in fact in our use case the returned list is exactly the actual
+ * list (see the comments in AEA).
  */
 public class PseudoListMatrix {
 

--- a/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
@@ -284,13 +284,11 @@ public class AdditionalEstimationAlgorithm {
             // Notifying the ItalianoAlgorithm to update.
             Iterable<Integer> it = i < j ? relationObservers.get(i, j) : relationObservers.get(j, i);
             for (int s : it) {
-                // By the nature of PseudoListMatrix, we need to check again to make sure
-                // subFaces[s] is what we want.
-                int I = subFaces[s].FaceIdIndex(i);
-                int J = subFaces[s].FaceIdIndex(j);
-                if (I != 0 && J != 0) {
-                    IA[s].add(I, J);
-                }
+                // Although PseudoListMatrix might return a larger list in general, here the
+                // returned list is actually exactly what we need, since a SubFace s is added to
+                // List[i][x] only if it contains Face i, and similarly it is added to List[x][j]
+                // only if it contains Face j.
+                IA[s].add(subFaces[s].FaceIdIndex(i), subFaces[s].FaceIdIndex(j));
             }
             return true;
         }

--- a/src/main/java/origami/folding/element/SubFace.java
+++ b/src/main/java/origami/folding/element/SubFace.java
@@ -26,8 +26,10 @@ public class SubFace {//This class folds the development view and estimates the 
     BulletinBoard bb;
 
     // For reverse swapping
-    private int reverseSwapCounter = 1;
-    public boolean reverseSwapFlag = false;
+    public int reverseSwapCounter = 0;
+    public int reverseSwapThreshold = 1;
+
+    public int swapCounter = 0;
 
     public SubFace() {
         reset();
@@ -111,9 +113,9 @@ public class SubFace {//This class folds the development view and estimates the 
             // strategically postpone it and try again after more stacking information is
             // determined. We do so by throwing TimeoutException notifying ct_worker to swap
             // this SubFace in reverse direction.
-            if (allowTimeout && permutationGenerator.getCount() > 3000 * reverseSwapCounter) {
+            if (allowTimeout && permutationGenerator.getCount() > 3000 * reverseSwapThreshold) {
+                reverseSwapThreshold++;
                 reverseSwapCounter++;
-                reverseSwapFlag = true;
                 throw new TimeoutException();
             }
 

--- a/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
+++ b/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
@@ -81,12 +81,12 @@ public class ChainPermutationGenerator extends PermutationGenerator {
             return 1;
         } else if (looped) {
             int i = 1; // Check if we have returned to the save point.
-            while (swapHistory[i] == saveHistory[2][i] && i<= numDigits) i++;
+            while (swapHistory[i] == saveHistory[2][i] && i < numDigits) i++;
             if (swapHistory[i] > saveHistory[2][i]) {
                 looped = false;
                 return 0;
             }
-        } else if(count >= 600 && count % 200 == 0) {
+        } else if (count >= 600 && count % 200 == 0) {
             if (count == 800) saved = true;
             for (int i = 1; i <= numDigits; i++) {
                 if (count >= 800) saveHistory[1][i] = saveHistory[0][i];
@@ -129,6 +129,12 @@ public class ChainPermutationGenerator extends PermutationGenerator {
 
             // If the current digit has no available element, retract.
             if (swapIndex > numDigits - lockRemain + 1) {
+                // The nature of ChainPermutationGenerator is that it never hits a dead-end
+                // mid-way unless there's internal contradiction in the given constraints.
+                if (swapHistory[curIndex] == curIndex - 1) {
+                    return 0;
+                }
+
                 swapHistory[curIndex] = curIndex - 1;
                 if (--curIndex == 0) {
                     return 0;


### PR DESCRIPTION
This PR improves the permutation generator and the reverse swapping strategy to better cope with CPs such as variants of Ryujin. It brings down the runtime of the fold-in-half version from 35 minutes to 17.