### PR TITLE
Memory optimization

### DIFF
--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -162,7 +162,7 @@ public class FoldedFigure_Worker {
                 }
             }
 
-            s0[i].setNumDigits(s0addFaceTotal, faceTotal);
+            s0[i].setNumDigits(s0addFaceTotal);
 
             for (int j = 1; j <= s0addFaceTotal; j++) {
                 s0[i].setFaceId(j, s0addFaceId[j]);//ここで面番号jは小さい方が先に追加される。


### PR DESCRIPTION
Memory profiling reveals that during the folding of Ryujin, more than 2G of memory is used on storing the faceIdMap arrays for the subfaces. Since the performance of hash maps and arrays is quite obvious in this case, it's a bad idea to swtich entirely to hash maps. By restricted the usage of array-based faceIdMap to only valid subfaces, we barely lose any speed but now Ryujin will fold with only 4G memory.