### PR TITLE
Search stage optimization

### DIFF
--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -276,6 +276,12 @@ public class FoldedFigure_Worker {
             return additional;
         }
         System.gc();
+        
+        // Here we can compare and see the huge difference before and after AEA
+        System.out.print("３面が関与する突き抜け条件の数　＝　");
+        System.out.println(hierarchyList.getEquivalenceConditionTotal());
+        System.out.print("４面が関与する突き抜け条件の数　＝　");
+        System.out.println(hierarchyList.getUEquivalenceConditionTotal());
 
         System.out.println("追加推定 終了し、上下表を保存------------------------＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊");
 
@@ -362,6 +368,7 @@ public class FoldedFigure_Worker {
 
         int capacity = FaceIdCount_max * FaceIdCount_max;
         AdditionalEstimationAlgorithm AEA = new AdditionalEstimationAlgorithm(bb, hierarchyList, s0, capacity);
+        AEA.removeMode = true;
         HierarchyListStatus result = AEA.run(0);
         errorPos = AEA.errorPos;
         return result;
@@ -427,7 +434,7 @@ public class FoldedFigure_Worker {
             // infer more stacking relations from our current set of permutation choices,
             // and this will greatly speed up the permutation generating (because of the
             // temporary guide mechanism) of later SubFaces.
-            AEA = new AdditionalEstimationAlgorithm(null, hierarchyList, s, SubFace_valid_number, 1000);
+            AEA = new AdditionalEstimationAlgorithm(hierarchyList, s, SubFace_valid_number, 1000);
             AEA.initialize();
         }
 
@@ -517,7 +524,7 @@ public class FoldedFigure_Worker {
         // Solution found, perform final checking
         bb.rewrite(10, " ");
         bb.rewrite(9, "Possible solution found...");
-        AEA = new AdditionalEstimationAlgorithm(null, hierarchyList, s, 1000); // we don't need much for this
+        AEA = new AdditionalEstimationAlgorithm(hierarchyList, s, 1000); // we don't need much for this
         if (AEA.run(SubFace_valid_number) != HierarchyListStatus.SUCCESSFUL_1000) {
             bb.rewrite(9, " ");
             // This rarely happens, but typically it means the solution contradicts some of

--- a/src/main/java/origami/folding/HierarchyList.java
+++ b/src/main/java/origami/folding/HierarchyList.java
@@ -21,7 +21,7 @@ public class HierarchyList {//This class is used to record and utilize the hiera
     // If hierarchyList[i][j] is -100, then faces i and j do not overlap.
     SymmetricMatrix hierarchyList;
     SymmetricMatrix hierarchyList_copy;
-    ArrayList<EquivalenceCondition> tL = new ArrayList<>();
+    List<EquivalenceCondition> tL = new LinkedList<>(); // We need LinkedList here for fast removal
     Queue<EquivalenceCondition> uL = new ConcurrentLinkedQueue<>();
 
     public HierarchyList() {

--- a/src/main/java/origami/folding/algorithm/SwappingAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/SwappingAlgorithm.java
@@ -45,7 +45,7 @@ public class SwappingAlgorithm {
         hash = getHash(s, high);
         if (history.contains(hash)) {
             // Introduce unvisited SubFaces to the game.
-            int reverseResult = reverseSwap(s, 1, max); // side effect on hash
+            int reverseResult = reverseSwap(s, 1, high, max, 1); // side effect on hash
             if (reverseResult == high) return; // Let's hope that this never happen, or we're out of tricks.
             else high = reverseResult;
         }
@@ -58,7 +58,7 @@ public class SwappingAlgorithm {
         high = 0;
 
 		// To further improve performance
-		reverseSwapCore(s, low, max, s[low].swapCounter - 1);
+		reverseSwap(s, low, low, max, s[low].swapCounter - 1);
 	}
 
     private int getHash(SubFace[] s, int high) {
@@ -88,21 +88,20 @@ public class SwappingAlgorithm {
         s[low] = temp;
     }
 
-    public int reverseSwap(SubFace[] s, int index, int max) {
-        return reverseSwapCore(s, index, max, ++repetition);
+    public void reverseSwap(SubFace[] s, int index, int max) {
+        reverseSwap(s, index, index, max, ++repetition);
     }
 
-    private int reverseSwapCore(SubFace[] s, int index, int max, int r) {
-        int result = index;
+    private int reverseSwap(SubFace[] s, int index, int high, int max, int r) {
         for (int i = index + 1; i <= max && r > 0; i++) {
             if (!visited.contains(s[i].id)) {
                 visited.add(s[i].id);
                 swap(s, i, index);
-                hash = getHash(s, ++result);
+                hash = getHash(s, ++high);
                 r--;
             }
         }
-        return result;
+        return high;
     }
 
     public void visit(SubFace s) {


### PR DESCRIPTION
We remove those EquivalenceConditions that are used during the first AEA run to both speed up all AEA (including realtime AEA) and permutation checking process. As a result, as long as there's no excess permutation, the search stage becomes so fast that my eyes can't catch up any more. Theoretically this also slightly reduce the memory usage.