### PR TITLE
Fix self-intersection highlighting

### DIFF
--- a/src/main/java/origami_editor/editor/App.java
+++ b/src/main/java/origami_editor/editor/App.java
@@ -12,6 +12,7 @@ import origami_editor.editor.canvas.*;
 import origami_editor.editor.component.BulletinBoard;
 import origami_editor.editor.databinding.*;
 import origami_editor.editor.drawing.FoldedFigure_Drawer;
+import origami_editor.editor.drawing.FoldedFigure_Worker_Drawer;
 import origami_editor.editor.export.Cp;
 import origami_editor.editor.export.Obj;
 import origami_editor.editor.export.Orh;
@@ -241,6 +242,7 @@ public class App {
                 FoldedFigure_Drawer item = foldedFiguresList.getElementAt(i);
                 item.setData(applicationModel);
             }
+            FoldedFigure_Worker_Drawer.setStaticData(applicationModel);
         });
 
         applicationModel.reload();

--- a/src/main/java/origami_editor/editor/drawing/FoldedFigure_Worker_Drawer.java
+++ b/src/main/java/origami_editor/editor/drawing/FoldedFigure_Worker_Drawer.java
@@ -29,7 +29,7 @@ public class FoldedFigure_Worker_Drawer {
 
     boolean antiAlias = true;
     boolean displayShadows = false; //Whether to display shadows. 0 is not displayed, 1 is displayed
-    boolean displaySsi = false;
+    static boolean displaySsi = false;
     private boolean displayNumbers = false;
 
     public FoldedFigure_Worker_Drawer(FoldedFigure_Worker worker) {
@@ -582,8 +582,11 @@ public class FoldedFigure_Worker_Drawer {
     }
 
     public void setData(ApplicationModel applicationModel) {
-        displaySsi = applicationModel.getDisplaySelfIntersection();
         displayNumbers = applicationModel.getDisplayNumbers();
+    }
+
+    public static void setStaticData(ApplicationModel applicationModel) {
+        displaySsi = applicationModel.getDisplaySelfIntersection(); 
     }
 
     public void getData(FoldedFigureModel foldedFigureModel) {


### PR DESCRIPTION
Before this PR, the self-intersection highlighting doesn't work properly when the the folded figure is created for the first time. The user would have to turn off-and-on the option to see the hightlighting. This is because `FoldedFigure_Worker_Drawer.setData()` method is not called when individual instance is constructed.

Since self-intersection is a global option in the menu bar, it makes more sense to make `displaySsi` a static variable, and it also helps fixing this bug by hooking it up with the event listener properly.