### PR TITLE
Disable realtime AEA if necessary

### DIFF
--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Configurator.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Configurator.java
@@ -237,6 +237,7 @@ public class FoldedFigure_Configurator {
         AEA = null; // Now we can release the memory
         System.gc();
         
+        worker.hierarchyList.sortEquivalenceConditions();
         // Here we can compare and see the huge difference before and after AEA
         System.out.print("３面が関与する突き抜け条件の数　＝　");
         System.out.println(worker.hierarchyList.getEquivalenceConditionTotal());

--- a/src/main/java/origami/folding/HierarchyList.java
+++ b/src/main/java/origami/folding/HierarchyList.java
@@ -83,6 +83,13 @@ public class HierarchyList {//This class is used to record and utilize the hiera
         tL.add(ec);
     }
 
+    /** Sort 3EC found by parallel processing, in order to get consistent running result. */
+    public void sortEquivalenceConditions() {
+        Collections.sort(tL, Comparator.comparingInt(EquivalenceCondition::getA)
+                .thenComparingInt(EquivalenceCondition::getB)
+                .thenComparingInt(EquivalenceCondition::getD));
+    }
+
     public int getUEquivalenceConditionTotal() {
         return uL.size();
     }

--- a/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
@@ -82,9 +82,6 @@ public class AdditionalEstimationAlgorithm {
 
         do {
             new_relations = 0;
-            if (bb != null) {
-                System.out.println("additional_estimation------------------------");
-            }
 
             int iS = 0;
             try {
@@ -163,6 +160,7 @@ public class AdditionalEstimationAlgorithm {
                 checkQuadrupleConstraint(tg);
             }
         } catch (InferenceFailureException e) {
+            errorPos = null;
             // We shall ignore any exception (see the comments in FoldedFigure_Worker).
         }
     }

--- a/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
@@ -150,7 +150,7 @@ public class AdditionalEstimationAlgorithm {
     }
 
     /** This is a faster version of run(). */
-    public void fastRun() {
+    public boolean fastRun() {
         try {
             flush();
             for (EquivalenceCondition tg : hierarchyList.getEquivalenceConditions()) {
@@ -159,9 +159,9 @@ public class AdditionalEstimationAlgorithm {
             for (EquivalenceCondition tg : hierarchyList.getUEquivalenceConditions()) {
                 checkQuadrupleConstraint(tg);
             }
+            return true;
         } catch (InferenceFailureException e) {
-            errorPos = null;
-            // We shall ignore any exception (see the comments in FoldedFigure_Worker).
+            return false;
         }
     }
 

--- a/src/main/java/origami/folding/element/SubFace.java
+++ b/src/main/java/origami/folding/element/SubFace.java
@@ -407,9 +407,6 @@ public class SubFace {
                 for (EquivalenceCondition ec : list) result.add(ec);
             }
         }
-        result.sort(
-                Comparator.comparingInt(EquivalenceCondition::getA).thenComparingInt(EquivalenceCondition::getB)
-                        .thenComparingInt(EquivalenceCondition::getD));
         return result;
     }
 


### PR DESCRIPTION
This PR disables realtime AEA for some CP in which it doesn't work. For those CPs, doing so actually makes it faster. Folded Ryujin now folds in only 76 seconds.