### PR TITLE
Improve toggleMV and cAMV performance

### DIFF
--- a/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -3095,9 +3095,9 @@ public class FoldLineSet {
             //Put a polygonal line with p as the end point in Narabebako
             if (s.getColor().isFoldingLine()) { //Auxiliary live lines are excluded at this stage
                 if (p.distance(s.getA()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
+                    nbox.addByWeight(s, OritaCalc.angle(s.getA(), s.getB()));
                 } else if (p.distance(s.getB()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
+                    nbox.addByWeight(s, OritaCalc.angle(s.getB(), s.getA()));
                 }
             }
 
@@ -3134,9 +3134,9 @@ public class FoldLineSet {
             LineSegment s = lineSegments.get(i);
             if (s.getColor().isFoldingLine()) { //この段階で補助活線は除く
                 if (t1.distance(s.getA()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
+                    nbox.addByWeight(s, OritaCalc.angle(s.getA(), s.getB()));
                 } else if (t1.distance(s.getB()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
+                    nbox.addByWeight(s, OritaCalc.angle(s.getB(), s.getA()));
                 }
             }
         }
@@ -3222,9 +3222,9 @@ public class FoldLineSet {
             LineSegment si = lineSegments.get(i);
             if (si.getColor().isFoldingLine()) { //Auxiliary live lines are excluded at this stage
                 if (b.distance(si.getA()) < hantei_kyori) {
-                    r_nbox.container_i_smallest_first(new WeightedValue<>(si, OritaCalc.angle(b, a, si.getA(), si.getB())));
+                    r_nbox.addByWeight(si, OritaCalc.angle(b, a, si.getA(), si.getB()));
                 } else if (b.distance(si.getB()) < hantei_kyori) {
-                    r_nbox.container_i_smallest_first(new WeightedValue<>(si, OritaCalc.angle(b, a, si.getB(), si.getA())));
+                    r_nbox.addByWeight(si, OritaCalc.angle(b, a, si.getB(), si.getA()));
                 }
             }
         }
@@ -3313,9 +3313,9 @@ public class FoldLineSet {
             LineSegment si = lineSegments.get(i);
             if (si.getColor().isFoldingLine()) { //この段階で補助活線は除く
                 if (t1.distance(si.getA()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(si, OritaCalc.angle(si.getA(), si.getB())));
+                    nbox.addByWeight(si, OritaCalc.angle(si.getA(), si.getB()));
                 } else if (t1.distance(si.getB()) < hantei_kyori) {
-                    nbox.container_i_smallest_first(new WeightedValue<>(si, OritaCalc.angle(si.getB(), si.getA())));
+                    nbox.addByWeight(si, OritaCalc.angle(si.getB(), si.getA()));
                 }
             }
         }

--- a/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -6,6 +6,7 @@ import origami.crease_pattern.element.Polygon;
 import origami.crease_pattern.element.*;
 import origami.data.quadTree.QuadTree;
 import origami.data.quadTree.adapter.LineSegmentListAdapter;
+import origami.data.quadTree.adapter.LineSegmentListEndPointAdapter;
 import origami.data.quadTree.collector.PointCollector;
 import origami.data.save.LineSegmentSave;
 import origami.folding.util.SortingBox;
@@ -3568,8 +3569,8 @@ public class FoldLineSet {
      */
     public void selectProbablyConnected(Point p) {
         // Build map of connections
-        QuadTree qtA = new QuadTree(new LineSegmentListAdapter(lineSegments, l -> l.getA()));
-        QuadTree qtB = new QuadTree(new LineSegmentListAdapter(lineSegments, l -> l.getB()));
+        QuadTree qtA = new QuadTree(new LineSegmentListEndPointAdapter(lineSegments, l -> l.getA()));
+        QuadTree qtB = new QuadTree(new LineSegmentListEndPointAdapter(lineSegments, l -> l.getB()));
 
         // Traverse connection map to find all connected points
         Set<Point> activePoints = new HashSet<>();

--- a/src/main/java/origami/crease_pattern/element/Polygon.java
+++ b/src/main/java/origami/crease_pattern/element/Polygon.java
@@ -3,7 +3,6 @@ package origami.crease_pattern.element;
 import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 public class Polygon {
     int vertexCount;             //How many vertices
@@ -138,7 +137,7 @@ public class Polygon {
         }
 
         for (int i = 1; i <= i_intersection; i++) {
-            nbox.container_i_smallest_first(new WeightedValue<>(intersection[i], intersection[i].distance(s0.getA())));
+            nbox.addByWeight(intersection[i], intersection[i].distance(s0.getA()));
         }
 
         // 0, when all of the line segment s0 exists outside the convex polygon (the boundary line is not considered inside)

--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Configurator.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Configurator.java
@@ -99,7 +99,6 @@ public class FoldedFigure_Configurator {
                 int s0addFaceTotal = 0;
     
                 for (int j : qt.collect(new PointCollector(subFace_insidePoint[iff]))) {
-                    j++; // qt is 0-based
                     if (otta_face_figure.inside(subFace_insidePoint[iff], j) == Polygon.Intersection.INSIDE) {
                         s0addFaceId[++s0addFaceTotal] = j;
                     }
@@ -320,7 +319,6 @@ public class FoldedFigure_Configurator {
                     Point q = otta_face_figure.getEndPointFromLineId(ibf);
                     // This qt here is the same instance as in SubFace_configure()
                     for (int im : qt.collect(new LineSegmentCollector(p, q))) {
-                        im++; // qt is 0-based
                         if ((im != faceId_min) && (im != faceId_max)) {
                             if (otta_face_figure.convex_inside(ibf, im)) {
                                 //下の２つのifは暫定的な処理。あとで置き換え予定
@@ -372,13 +370,12 @@ public class FoldedFigure_Configurator {
             final int mi2 = orite.lineInFaceBorder_max_request(ibf);
             if (mi1 != mi2 && mi1 != 0) {
                 service.execute(() -> {
-                    for (int jb : qt.getPotentialCollision(ibf - 1)) { // qt is 0-based
+                    for (int jb : qt.getPotentialCollision(ibf)) {
                         if (Thread.interrupted()) break;
-                        final int jbf = jb + 1; // qt is 0-based
-                        int mj1 = orite.lineInFaceBorder_min_request(jbf);
-                        int mj2 = orite.lineInFaceBorder_max_request(jbf);
+                        int mj1 = orite.lineInFaceBorder_min_request(jb);
+                        int mj2 = orite.lineInFaceBorder_max_request(jb);
                         if (mj1 != mj2 && mj1 != 0) {
-                            if (otta_face_figure.parallel_overlap(ibf, jbf)) {
+                            if (otta_face_figure.parallel_overlap(ibf, jb)) {
                                 if (exist_identical_subFace(mi1, mi2, mj1, mj2)) {
                                     // AEA cannot run in parallel
                                     synchronized (AEA) {

--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -180,7 +180,7 @@ public class FoldedFigure_Worker {
 
                 boolean success = true;
                 boolean se = swapper.shouldEstimate(ss); // side effect
-                if (se && ss <= Math.sqrt(SubFace_valid_number)) {                   
+                if (se && ss <= Math.sqrt(SubFace_valid_number)) {
                     success = AEA.run(0) == HierarchyListStatus.SUCCESSFUL_1000;
                 } else if (ss % (3 + ss * ss / 6400) == 0) {
                     // There's no need to execute run() even fastRun() in every step (that will be

--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -8,7 +8,6 @@ import origami.folding.element.SubFace;
 import origami.folding.util.EquivalenceCondition;
 import origami.folding.util.IBulletinBoard;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 
 /**
@@ -271,7 +270,7 @@ public class FoldedFigure_Worker {
 
         nbox.reset();
         for (int i = 1; i <= hierarchyList.getFacesTotal(); i++) {
-            nbox.container_i_smallest_first(new WeightedValue<>(i, face_rating[i]));
+            nbox.addByWeight(i, face_rating[i]);
         }
 
         return nbox;

--- a/src/main/java/origami/crease_pattern/worker/WireFrame_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/WireFrame_Worker.java
@@ -113,7 +113,6 @@ public class WireFrame_Worker {
         for (int it = 1; it <= this.pointSet.getNumPoints(); it++) {
             tnew[it].reset();
             for (int im : qt.collect(new PointCollector(pointSet.getPoint(it)))) {
-                im++; // qt is 0-based
                 if (pointSet.pointInFaceBorder(im, it)) {//c.Ten_moti_hantei returns 1 if the boundary of Face [im] contains Point [it], 0 if it does not.
                     tnew[it].addPoint(fold_movement(it, im));
                     pointSet.setPoint(it, tnew[it].getAveragePoint());
@@ -164,8 +163,8 @@ public class WireFrame_Worker {
         while (remaining_facesTotal > 0) {
             SortedSet<Integer> nextRound = new TreeSet<>();
             for (int i : currentRound) {
-                for (int j : qt.getPotentialCollision(i - 1, -1)) {
-                    if (iFacePosition[++j] != 0) continue;
+                for (int j : qt.getPotentialCollision(i, 0)) {
+                    if (iFacePosition[j] != 0) continue;
                     int mth = pointSet.findAdjacentLine(i, j, map);
                     if (mth > 0) {
                         nextRound.add(j);
@@ -281,14 +280,12 @@ public class WireFrame_Worker {
         for (int n = 0; n < lineSegmentSet.getNumLineSegments(); n++) {
             int start = 0, end = 0;
             for (int i : qt.collect(new PointCollector(lineSegmentSet.getA(n)))) {
-                i++; // qt is 0-based
                 if (OritaCalc.equal(lineSegmentSet.getA(n), pointSet.getPoint(i))) {
                     start = i;
                     break;
                 }
             }
             for (int i : qt.collect(new PointCollector(lineSegmentSet.getB(n)))) {
-                i++; // qt is 0-based
                 if (OritaCalc.equal(lineSegmentSet.getB(n), pointSet.getPoint(i))) {
                     end = i;
                     break;

--- a/src/main/java/origami/data/quadTree/QuadTree.java
+++ b/src/main/java/origami/data/quadTree/QuadTree.java
@@ -27,6 +27,7 @@ public class QuadTree {
     /** Which node contains the QuadTreeItem. */
     private final ArrayList<Node> map;
 
+    private final int offset;
     private int count;
 
     public QuadTree(QuadTreeAdapter adapter) {
@@ -35,6 +36,7 @@ public class QuadTree {
 
     public QuadTree(QuadTreeAdapter adapter, QuadTreeComparator comparator) {
         this.adapter = adapter;
+        this.offset = adapter.getOffset();
         this.comparator = comparator;
         next = new ArrayList<>();
         map = new ArrayList<>();
@@ -84,7 +86,7 @@ public class QuadTree {
     }
 
     public Iterable<Integer> getPotentialCollision(int i, int min) {
-        return collect(new CollisionCollector(i, min, map));
+        return collect(new CollisionCollector(i - offset, min - offset, map));
     }
 
     public Iterable<Integer> collect(QuadTreeCollector collector) {
@@ -114,7 +116,7 @@ public class QuadTree {
         int cursor = node.head;
         while (cursor != -1) {
             if (collector.shouldCollect(cursor, adapter)) {
-                heap.add(cursor);
+                heap.add(cursor + offset);
             }
             cursor = next.get(cursor);
         }

--- a/src/main/java/origami/data/quadTree/QuadTreeItem.java
+++ b/src/main/java/origami/data/quadTree/QuadTreeItem.java
@@ -7,6 +7,21 @@ public class QuadTreeItem {
     public static final double EPSILON = Epsilon.QUAD_TREE_ITEM;
     public final double l, r, b, t;
 
+    public QuadTreeItem(Point p) {
+        double x = p.getX(), y = p.getY();
+        this.l = this.r = x;
+        this.b = this.t = y;
+    }
+
+    public QuadTreeItem(Point A, Point B) {
+        double ax = A.getX(), ay = A.getY();
+        double bx = B.getX(), by = B.getY();
+        this.l = Math.min(ax, bx);
+        this.r = Math.max(ax, bx);
+        this.b = Math.min(ay, by);
+        this.t = Math.max(ay, by);
+    }
+
     public QuadTreeItem(double l, double r, double b, double t) {
         this.l = l;
         this.r = r;

--- a/src/main/java/origami/data/quadTree/adapter/CamvAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/CamvAdapter.java
@@ -6,40 +6,39 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami.data.quadTree.QuadTreeItem;
 
-public class LineSegmentListAdapter implements QuadTreeAdapter {
+public class CamvAdapter implements QuadTreeAdapter {
 
     private final List<LineSegment> list;
-    private final int offset;
+    private final List<Point> points;
 
-    public LineSegmentListAdapter(List<LineSegment> list, int offset) {
+    public CamvAdapter(List<LineSegment> list, List<Point> points) {
         this.list = list;
-        this.offset = offset;
+        this.points = points;
     }
 
     @Override
     public int getCount() {
-        return list.size() - offset;
+        return points.size();
     }
 
     @Override
     public QuadTreeItem getItem(int index) {
-        LineSegment l = list.get(index + offset);
-        return new QuadTreeItem(l.getA(), l.getB());
+        return new QuadTreeItem(points.get(index));
     }
 
     @Override
     public int getPointCount() {
-        return (list.size() - offset) * 2;
+        return (list.size() - 1) * 2;
     }
 
     @Override
     public Point getPoint(int index) {
-        LineSegment l = list.get(index / 2 + offset);
+        LineSegment l = list.get(index / 2 + 1);
         return index % 2 == 0 ? l.getA() : l.getB();
     }
 
     @Override
     public int getOffset() {
-        return offset;
+        return 0;
     }
 }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentEndPointAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentEndPointAdapter.java
@@ -43,4 +43,9 @@ public class LineSegmentEndPointAdapter implements QuadTreeAdapter {
     public Point getPoint(int index) {
         return factory.apply(set, index);
     }
+
+    @Override
+    public int getOffset() {
+        return 0;
+    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentListAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentListAdapter.java
@@ -38,4 +38,9 @@ public class LineSegmentListAdapter implements  QuadTreeAdapter {
     public Point getPoint(int index) {
         return factory.apply(list.get(index));
     }
+
+    @Override
+    public int getOffset() {
+        return 0;
+    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentListAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentListAdapter.java
@@ -1,0 +1,45 @@
+package origami.data.quadTree.adapter;
+
+import java.util.List;
+
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+import origami.data.quadTree.QuadTreeItem;
+
+public class LineSegmentListAdapter implements QuadTreeAdapter {
+
+    private final List<LineSegment> list;
+    private final int offset;
+
+    public LineSegmentListAdapter(List<LineSegment> list, int offset) {
+        this.list = list;
+        this.offset = offset;
+    }
+
+    @Override
+    public int getCount() {
+        return list.size() - offset;
+    }
+
+    @Override
+    public QuadTreeItem getItem(int index) {
+        LineSegment l = list.get(index + offset);
+        return QuadTreeAdapter.createItem(l.getA(), l.getB());
+    }
+
+    @Override
+    public int getPointCount() {
+        return (list.size() - offset) * 2;
+    }
+
+    @Override
+    public Point getPoint(int index) {
+        LineSegment l = list.get(index / 2 + offset);
+        return index % 2 == 0 ? l.getA() : l.getB();
+    }
+
+    @Override
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentListEndPointAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentListEndPointAdapter.java
@@ -7,12 +7,12 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami.data.quadTree.QuadTreeItem;
 
-public class LineSegmentListAdapter implements  QuadTreeAdapter {
+public class LineSegmentListEndPointAdapter implements  QuadTreeAdapter {
 
     private final List<LineSegment> list;
     private final Function<LineSegment, Point> factory;
 
-    public LineSegmentListAdapter(List<LineSegment> list, Function<LineSegment, Point> factory) {
+    public LineSegmentListEndPointAdapter(List<LineSegment> list, Function<LineSegment, Point> factory) {
         this.list = list;
         this.factory= factory;
     }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentSetAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentSetAdapter.java
@@ -26,4 +26,9 @@ public abstract class LineSegmentSetAdapter implements QuadTreeAdapter {
     public Point getPoint(int index) {
         return index % 2 == 0 ? set.getA(index / 2) : set.getB(index / 2);
     }
+
+    @Override
+    public int getOffset() {
+        return 0;
+    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentSetLineAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentSetLineAdapter.java
@@ -22,6 +22,6 @@ public class LineSegmentSetLineAdapter extends LineSegmentSetAdapter {
 
     @Override
     public QuadTreeItem getItem(int index) {
-        return QuadTreeAdapter.createItem(set.getA(index), set.getB(index));
+        return new QuadTreeItem(set.getA(index), set.getB(index));
     }
 }

--- a/src/main/java/origami/data/quadTree/adapter/LineSegmentSetLineAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/LineSegmentSetLineAdapter.java
@@ -1,7 +1,6 @@
 package origami.data.quadTree.adapter;
 
 import origami.crease_pattern.LineSegmentSet;
-import origami.crease_pattern.element.Point;
 import origami.data.quadTree.QuadTreeItem;
 
 /**
@@ -23,12 +22,6 @@ public class LineSegmentSetLineAdapter extends LineSegmentSetAdapter {
 
     @Override
     public QuadTreeItem getItem(int index) {
-        return createItem(set.getA(index), set.getB(index));
-    }
-
-    public static QuadTreeItem createItem(Point A, Point B) {
-        double ax = A.getX(), ay = A.getY();
-        double bx = B.getX(), by = B.getY();
-        return new QuadTreeItem(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by));
+        return QuadTreeAdapter.createItem(set.getA(index), set.getB(index));
     }
 }

--- a/src/main/java/origami/data/quadTree/adapter/PointSetAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/PointSetAdapter.java
@@ -27,4 +27,9 @@ public abstract class PointSetAdapter implements QuadTreeAdapter {
         // Points in PointSet are 1-based
         return set.getPoint(index + 1);
     }
+    
+    @Override
+    public int getOffset() {
+        return 1;
+    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
@@ -25,10 +25,4 @@ public interface QuadTreeAdapter {
 
     /** Get index offset. */
     public int getOffset();
-
-    public static QuadTreeItem createItem(Point A, Point B) {
-        double ax = A.getX(), ay = A.getY();
-        double bx = B.getX(), by = B.getY();
-        return new QuadTreeItem(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by));
-    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
@@ -25,4 +25,10 @@ public interface QuadTreeAdapter {
 
     /** Get index offset. */
     public int getOffset();
+
+    public static QuadTreeItem createItem(Point A, Point B) {
+        double ax = A.getX(), ay = A.getY();
+        double bx = B.getX(), by = B.getY();
+        return new QuadTreeItem(Math.min(ax, bx), Math.max(ax, bx), Math.min(ay, by), Math.max(ay, by));
+    }
 }

--- a/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
+++ b/src/main/java/origami/data/quadTree/adapter/QuadTreeAdapter.java
@@ -22,4 +22,7 @@ public interface QuadTreeAdapter {
 
     /** Get a point for initialization. */
     public Point getPoint(int index);
+
+    /** Get index offset. */
+    public int getOffset();
 }

--- a/src/main/java/origami/data/quadTree/collector/LineSegmentCollector.java
+++ b/src/main/java/origami/data/quadTree/collector/LineSegmentCollector.java
@@ -3,7 +3,6 @@ package origami.data.quadTree.collector;
 import origami.crease_pattern.element.Point;
 import origami.data.quadTree.QuadTreeItem;
 import origami.data.quadTree.QuadTree.Node;
-import origami.data.quadTree.adapter.LineSegmentSetLineAdapter;
 import origami.data.quadTree.adapter.QuadTreeAdapter;
 
  /** Get all items that might partially contains the given line. */
@@ -12,7 +11,7 @@ public class LineSegmentCollector extends RecursiveCollector {
     private QuadTreeItem item;
 
     public LineSegmentCollector(Point p, Point q) {
-        this.item = LineSegmentSetLineAdapter.createItem(p, q);
+        this.item = QuadTreeAdapter.createItem(p, q);
     }
 
     @Override

--- a/src/main/java/origami/data/quadTree/collector/LineSegmentCollector.java
+++ b/src/main/java/origami/data/quadTree/collector/LineSegmentCollector.java
@@ -5,13 +5,13 @@ import origami.data.quadTree.QuadTreeItem;
 import origami.data.quadTree.QuadTree.Node;
 import origami.data.quadTree.adapter.QuadTreeAdapter;
 
- /** Get all items that might partially contains the given line. */
+/** Get all items that might partially contains the given line. */
 public class LineSegmentCollector extends RecursiveCollector {
 
     private QuadTreeItem item;
 
     public LineSegmentCollector(Point p, Point q) {
-        this.item = QuadTreeAdapter.createItem(p, q);
+        this.item = new QuadTreeItem(p, q);
     }
 
     @Override

--- a/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
@@ -283,7 +283,7 @@ public class AdditionalEstimationAlgorithm {
     }
 
     /** Caller of this method must be certain that no error will occur. */
-    public boolean inferAbove(int i, int j) {
+    public boolean inferAbove(int i, int j) throws InferenceFailureException {
         if (hierarchyList.isEmpty(i, j)) {
             hierarchyList.set(i, j, ABOVE);
 
@@ -294,7 +294,9 @@ public class AdditionalEstimationAlgorithm {
                 // returned list is actually exactly what we need, since a SubFace s is added to
                 // List[i][x] only if it contains Face i, and similarly it is added to
                 // List[x][j] only if it contains Face j.
-                IA[s].add(subFaces[s].FaceIdIndex(i), subFaces[s].FaceIdIndex(j));
+                if(!IA[s].tryAdd(subFaces[s].FaceIdIndex(i), subFaces[s].FaceIdIndex(j))) {
+                    throw new InferenceFailureException(i, j);
+                }
             }
             return true;
         }
@@ -370,16 +372,6 @@ public class AdditionalEstimationAlgorithm {
         new_relations = 0;
         for (int iS = 1; iS < count; iS++) {
             new_relations += checkTransitivity(iS);
-        }
-    }
-
-    private static class InferenceFailureException extends Exception {
-        final int i;
-        final int j;
-
-        public InferenceFailureException(int i, int j) {
-            this.i = i;
-            this.j = j;
         }
     }
 }

--- a/src/main/java/origami/folding/algorithm/InferenceFailureException.java
+++ b/src/main/java/origami/folding/algorithm/InferenceFailureException.java
@@ -1,0 +1,11 @@
+package origami.folding.algorithm;
+
+public class InferenceFailureException extends Exception {
+    final int i;
+    final int j;
+
+    public InferenceFailureException(int i, int j) {
+        this.i = i;
+        this.j = j;
+    }
+}

--- a/src/main/java/origami/folding/algorithm/italiano/ItalianoAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/italiano/ItalianoAlgorithm.java
@@ -51,6 +51,12 @@ public class ItalianoAlgorithm {
         }
     }
 
+    public final boolean tryAdd(int i, int j) {
+        if (matrix[j][i] != 0) return false;
+        add(i, j);
+        return true;
+    }
+
     public final void add(int i, int j) {
         if (matrix[i][j] == 0) {
             for (int x = 1; x <= size; x++) {

--- a/src/main/java/origami/folding/permutation/combination/CombinationGenerator.java
+++ b/src/main/java/origami/folding/permutation/combination/CombinationGenerator.java
@@ -3,6 +3,7 @@ package origami.folding.permutation.combination;
 import java.util.*;
 
 import origami.folding.HierarchyList;
+import origami.folding.algorithm.InferenceFailureException;
 import origami.folding.algorithm.italiano.ReductionItalianoAlgorithm;
 import origami.folding.algorithm.swapping.SwappingAlgorithm;
 import origami.folding.element.SubFace;
@@ -32,14 +33,17 @@ public class CombinationGenerator {
     // debugging.
     private int count = 0;
 
-    public CombinationGenerator(SubFace s, int[] faceIdMapArray, HierarchyList hierarchyList) {
+    public CombinationGenerator(SubFace s, int[] faceIdMapArray, HierarchyList hierarchyList) throws InferenceFailureException {
         faceIdCount = s.getFaceIdCount();
         ia = new ReductionItalianoAlgorithm(faceIdCount);
         for (int i = 1; i <= faceIdCount; i++) {
             for (int j = i + 1; j <= faceIdCount; j++) {
                 int state = hierarchyList.get(s.getFaceId(i), s.getFaceId(j));
-                if (state == HierarchyList.ABOVE_1) ia.add(i, j);
-                else if (state == HierarchyList.BELOW_0) ia.add(j, i);
+                if (state == HierarchyList.ABOVE_1) {
+                    if(!ia.tryAdd(i, j)) throw new InferenceFailureException(i, j);
+                } else if (state == HierarchyList.BELOW_0) {
+                    if(!ia.tryAdd(j, i)) throw new InferenceFailureException(i, j);
+                }
             }
         }
         ia.save();

--- a/src/main/java/origami/folding/util/SortingBox.java
+++ b/src/main/java/origami/folding/util/SortingBox.java
@@ -35,33 +35,24 @@ public class SortingBox<T> {//Arrange and store data in ascending order of doubl
     }
 
     public T getValue(int i) {//Returns an int that is the value-th order as a result of being arranged
-        WeightedValue<T> i_d_temp = new WeightedValue<>();
-        i_d_temp.set(i_d_List.get(i));
-        return i_d_temp.getValue();
+        return i_d_List.get(i).getValue();
     }
 
     public T backwardsGetValue(int iu) {//Returns the value-th int from the back
         int i = getTotal() + 1 - iu;
-        WeightedValue<T> i_d_temp = new WeightedValue<>();
-        i_d_temp.set(i_d_List.get(i));
-        return i_d_temp.getValue();
+        return i_d_List.get(i).getValue();
     }
 
     public double getWeight(int i) {//As a result of arranging, returns a double paired with an int that is in the value-th order.
-        WeightedValue<T> i_d_temp = new WeightedValue<>();
-        i_d_temp.set(i_d_List.get(i));
-        return i_d_temp.getWeight();
+        return i_d_List.get(i).getWeight();
     }
 
     public void add(WeightedValue<T> i_d_0) {//Simply add int_double to the end
         i_d_List.add(i_d_0);
     }
 
-    public void add(int i, WeightedValue<T> i_d_0) {//int_doubleを単にi番目にに加える（挿入する）
-        i_d_List.add(i, i_d_0);
-    }
-
-    public void container_i_smallest_first(WeightedValue<T> i_d_0) {//The meaning of the name of this function is to put value in ascending order of weight, but it may be confusing.
+    public void addByWeight(T value, double weight) {
+        WeightedValue<T> i_d_0 = new WeightedValue<>(value, weight);
         for (int i = 1; i <= getTotal(); i++) {
             if (i_d_0.getWeight() < getWeight(i)) {
                 i_d_List.add(i, i_d_0);

--- a/src/main/java/origami_editor/editor/action/MouseHandlerChangeStandardFace.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerChangeStandardFace.java
@@ -58,10 +58,9 @@ public class MouseHandlerChangeStandardFace extends BaseMouseHandler {
 
             System.out.println("kijyunmen_id = " + newStartingFaceId);
             if (selectedFigure.foldedFigure.ct_worker.face_rating != null) {//20180227追加
+                int index = selectedFigure.foldedFigure.ct_worker.nbox.getSequence(newStartingFaceId);
                 System.out.println(
-                        "OZ.js.nbox.get_jyunjyo = " + selectedFigure.foldedFigure.ct_worker.nbox.getSequence(newStartingFaceId) + " , rating = " +
-                                selectedFigure.foldedFigure.ct_worker.nbox.getWeight(selectedFigure.foldedFigure.ct_worker.nbox.getSequence(newStartingFaceId))
-
+                        "OZ.js.nbox.get_jyunjyo = " + index + " , rating = " + selectedFigure.foldedFigure.ct_worker.nbox.getWeight(index)
                 );
 
             }

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeEdge.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeEdge.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
+import origami_editor.editor.canvas.CreasePattern_Worker;
 import origami_editor.editor.canvas.MouseMode;
 
 @Singleton
@@ -23,8 +24,15 @@ public class MouseHandlerCreaseMakeEdge extends BaseMouseHandlerBoxSelect {
 
     }
 
-    //マウス操作(mouseMode==25 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    /**
+     * マウス操作(mouseMode==25 でボタンを離したとき)を行う関数
+     * 
+     * The reason for doing {@link CreasePattern_Worker#fix2()} at the end of this
+     * process is to correct the T-shaped disconnection that frequently occurs in
+     * the combination of the original polygonal line and the polygonal line
+     * converted from the auxiliary line.
+     */
+    public void mouseReleased(Point p0) {
         d.lineStep.clear();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeMV.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeMV.java
@@ -9,7 +9,6 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.canvas.MouseMode;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 @Singleton
 public class MouseHandlerCreaseMakeMV extends BaseMouseHandlerInputRestricted {
@@ -59,8 +58,7 @@ public class MouseHandlerCreaseMakeMV extends BaseMouseHandlerInputRestricted {
                     for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                         LineSegment s = d.foldLineSet.get(i);
                         if (OritaCalc.isLineSegmentOverlapping(s, d.lineStep.get(0))) {
-                            WeightedValue<LineSegment> i_d = new WeightedValue<>(s, OritaCalc.determineLineSegmentDistance(d.lineStep.get(0).getB(), s));
-                            nbox.container_i_smallest_first(i_d);
+                            nbox.addByWeight(s, OritaCalc.determineLineSegmentDistance(d.lineStep.get(0).getB(), s));
                         }
                     }
 

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeMountain.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeMountain.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
+import origami_editor.editor.canvas.CreasePattern_Worker;
 import origami_editor.editor.canvas.MouseMode;
 
 @Singleton
@@ -23,8 +24,15 @@ public class MouseHandlerCreaseMakeMountain extends BaseMouseHandlerBoxSelect {
 
     }
 
-    //マウス操作(mouseMode==23 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    /**
+     * マウス操作(mouseMode==23 でボタンを離したとき)を行う関数
+     * 
+     * The reason for doing {@link CreasePattern_Worker#fix2()} at the end of this
+     * process is to correct the T-shaped disconnection that frequently occurs in
+     * the combination of the original polygonal line and the polygonal line
+     * converted from the auxiliary line.
+     */
+    public void mouseReleased(Point p0) {
         d.lineStep.clear();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeValley.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreaseMakeValley.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
+import origami_editor.editor.canvas.CreasePattern_Worker;
 import origami_editor.editor.canvas.MouseMode;
 
 @Singleton
@@ -23,8 +24,15 @@ public class MouseHandlerCreaseMakeValley extends BaseMouseHandlerBoxSelect {
 
     }
 
-    //マウス操作(mouseMode==24 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    /**
+     * マウス操作(mouseMode==24 でボタンを離したとき)を行う関数
+     * 
+     * The reason for doing {@link CreasePattern_Worker#fix2()} at the end of this
+     * process is to correct the T-shaped disconnection that frequently occurs in
+     * the combination of the original polygonal line and the polygonal line
+     * converted from the auxiliary line.
+     */
+    public void mouseReleased(Point p0) {
         d.lineStep.clear();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreaseToggleMV.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreaseToggleMV.java
@@ -6,6 +6,7 @@ import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
+import origami_editor.editor.canvas.CreasePattern_Worker;
 import origami_editor.editor.canvas.MouseMode;
 
 @Singleton
@@ -24,13 +25,16 @@ public class MouseHandlerCreaseToggleMV extends BaseMouseHandlerBoxSelect {
 
     }
 
-    //マウス操作(mouseMode==58線_変換　でボタンを離したとき)を行う関数
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    /**
+     * マウス操作(mouseMode==58線_変換 でボタンを離したとき)を行う関数
+     * 
+     * Toggling M/V creases cannot possibly create new T-intersections, so we dont' need {@link CreasePattern_Worker#fix2()} here.
+     */
+    public void mouseReleased(Point p0) {
         d.lineStep.clear();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//
             if (d.MV_change(selectionStart, p0) != 0) {
-                d.fix2();
                 d.record();
             }
         }
@@ -47,7 +51,6 @@ public class MouseHandlerCreaseToggleMV extends BaseMouseHandlerBoxSelect {
                     s.setColor(LineColor.RED_1);
                 }
 
-                d.fix2();
                 d.record();
             }
 

--- a/src/main/java/origami_editor/editor/action/MouseHandlerCreasesAlternateMV.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerCreasesAlternateMV.java
@@ -9,7 +9,6 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.canvas.MouseMode;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 @Singleton
 public class MouseHandlerCreasesAlternateMV extends BaseMouseHandlerInputRestricted {
@@ -70,8 +69,7 @@ public class MouseHandlerCreasesAlternateMV extends BaseMouseHandlerInputRestric
                     }
 
                     if (i_jikkou == 1) {
-                        WeightedValue<LineSegment> i_d = new WeightedValue<>(s, OritaCalc.distance(d.lineStep.get(0).getB(), OritaCalc.findIntersection(s, d.lineStep.get(0))));
-                        nbox.container_i_smallest_first(i_d);
+                        nbox.addByWeight(s, OritaCalc.distance(d.lineStep.get(0).getB(), OritaCalc.findIntersection(s, d.lineStep.get(0))));
                     }
                 }
 

--- a/src/main/java/origami_editor/editor/action/MouseHandlerFlatFoldableCheck.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerFlatFoldableCheck.java
@@ -9,7 +9,6 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.canvas.MouseMode;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 @Singleton
 public class MouseHandlerFlatFoldableCheck extends BaseMouseHandler {
@@ -113,15 +112,13 @@ public class MouseHandlerFlatFoldableCheck extends BaseMouseHandler {
 
 
                     if (i_jikkou == 1) {
-                        WeightedValue<LineSegment> i_d = new WeightedValue<>(s, OritaCalc.distance(s2.getA(), OritaCalc.findIntersection(s, s2)));
-                        nbox.container_i_smallest_first(i_d);
+                        nbox.addByWeight(s, OritaCalc.distance(s2.getA(), OritaCalc.findIntersection(s, s2)));
                     }
                 }
 
 
                 for (int i = 1; i <= nbox.getTotal(); i++) {
-                    WeightedValue<LineSegment> i_d = new WeightedValue<>(nbox.getValue(i), goukei_nbox.getTotal());
-                    goukei_nbox.container_i_smallest_first(i_d);
+                    goukei_nbox.addByWeight(nbox.getValue(i), goukei_nbox.getTotal());
                 }
             }
             System.out.println(" --------------------------------");

--- a/src/main/java/origami_editor/editor/action/MouseHandlerFoldableLineDraw.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerFoldableLineDraw.java
@@ -7,7 +7,6 @@ import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 import origami_editor.editor.canvas.MouseMode;
 import origami_editor.editor.canvas.FoldLineAdditionalInputMode;
 
@@ -72,9 +71,9 @@ public class MouseHandlerFoldableLineDraw extends BaseMouseHandler {
                 LineSegment s = d.foldLineSet.get(i);
                 if (s.getColor().isFoldingLine()) {
                     if (closest_point.distance(s.getA()) < decision_distance) {
-                        nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
+                        nbox.addByWeight(s, OritaCalc.angle(s.getA(), s.getB()));
                     } else if (closest_point.distance(s.getB()) < decision_distance) {
-                        nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
+                        nbox.addByWeight(s, OritaCalc.angle(s.getB(), s.getA()));
                     }
                 }
             }

--- a/src/main/java/origami_editor/editor/action/MouseHandlerFoldableLineInput.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerFoldableLineInput.java
@@ -9,7 +9,6 @@ import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.canvas.MouseMode;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 import origami_editor.editor.canvas.CreasePattern_Worker;
 
 @Singleton
@@ -134,9 +133,9 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
                         LineSegment s = d.foldLineSet.get(i);
                         if (s.getColor().isFoldingLine()) {
                             if (closest_point.distance(s.getA()) < decision_distance) {
-                                nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
+                                nbox.addByWeight(s, OritaCalc.angle(s.getA(), s.getB()));
                             } else if (closest_point.distance(s.getB()) < decision_distance) {
-                                nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
+                                nbox.addByWeight(s, OritaCalc.angle(s.getB(), s.getA()));
                             }
                         }
                     }

--- a/src/main/java/origami_editor/editor/action/MouseHandlerLengthenCrease.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerLengthenCrease.java
@@ -10,7 +10,6 @@ import origami.crease_pattern.element.Point;
 import origami.crease_pattern.element.StraightLine;
 import origami_editor.editor.canvas.MouseMode;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 
 @Singleton
 public class MouseHandlerLengthenCrease extends BaseMouseHandler {
@@ -83,15 +82,14 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                 boolean i_jikkou = i_lineSegment_intersection_decision == LineSegment.Intersection.INTERSECTS_1;
 
                 if (i_jikkou) {
-                    WeightedValue<LineSegment> i_d = new WeightedValue<>(s, OritaCalc.distance(d.lineStep.get(0).getA(), OritaCalc.findIntersection(s, d.lineStep.get(0))));
-                    entyou_kouho_nbox.container_i_smallest_first(i_d);
+                    entyou_kouho_nbox.addByWeight(s, OritaCalc.distance(d.lineStep.get(0).getA(), OritaCalc.findIntersection(s, d.lineStep.get(0))));
                 }
             }
 
             if ((entyou_kouho_nbox.getTotal() == 0) && (d.lineStep.get(0).determineLength() <= Epsilon.UNKNOWN_1EN6)) {//延長する候補になる折線を選ぶために描いた線分s_step[1]が点状のときの処理
                 if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
-                    WeightedValue<LineSegment> i_d = new WeightedValue<>(d.foldLineSet.closestLineSegmentSearch(p), 1.0);//entyou_kouho_nboxに1本の情報しか入らないのでdoubleの部分はどうでもよいので適当に1.0にした。
-                    entyou_kouho_nbox.container_i_smallest_first(i_d);
+                    //entyou_kouho_nboxに1本の情報しか入らないのでdoubleの部分はどうでもよいので適当に1.0にした。
+                    entyou_kouho_nbox.addByWeight(d.foldLineSet.closestLineSegmentSearch(p), 1.0);
 
                     d.lineStep.get(0).setB(OritaCalc.findLineSymmetryPoint(closestLineSegment.getA(), closestLineSegment.getB(), p));
 

--- a/src/main/java/origami_editor/editor/action/MouseHandlerVertexMakeAngularlyFlatFoldable.java
+++ b/src/main/java/origami_editor/editor/action/MouseHandlerVertexMakeAngularlyFlatFoldable.java
@@ -6,7 +6,6 @@ import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami.folding.util.SortingBox;
-import origami.folding.util.WeightedValue;
 import origami_editor.editor.canvas.MouseMode;
 import origami_editor.editor.canvas.CreasePattern_Worker;
 
@@ -96,9 +95,9 @@ public class MouseHandlerVertexMakeAngularlyFlatFoldable extends BaseMouseHandle
                         LineSegment s = d.foldLineSet.get(i);
                         if (s.getColor().isFoldingLine()) {
                             if (t1.distance(s.getA()) < decision_distance) {
-                                nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
+                                nbox.addByWeight(s, OritaCalc.angle(s.getA(), s.getB()));
                             } else if (t1.distance(s.getB()) < decision_distance) {
-                                nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
+                                nbox.addByWeight(s, OritaCalc.angle(s.getB(), s.getA()));
                             }
                         }
                     }

--- a/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
+++ b/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
@@ -357,39 +357,13 @@ public class CreasePattern_Worker {
 
     public String undo() {
         s_title = setMemo_for_redo_undo(historyState.undo());
-
-        if (check1) {
-            check1();
-        }
-        if (check2) {
-            check2();
-        }
-        if (check3) {
-            check3();
-        }
-        if (check4) {
-            check4();
-        }
-
+        checkIfNecessary();
         return s_title;
     }
 
     public String redo() {
         s_title = setMemo_for_redo_undo(historyState.redo());
-
-        if (check1) {
-            check1();
-        }
-        if (check2) {
-            check2();
-        }
-        if (check3) {
-            check3();
-        }
-        if (check4) {
-            check4();
-        }
-
+        checkIfNecessary();
         return s_title;
     }
 
@@ -398,18 +372,7 @@ public class CreasePattern_Worker {
     }
 
     public void record() {
-        if (check1) {
-            check1();
-        }
-        if (check2) {
-            check2();
-        }
-        if (check3) {
-            check3();
-        }
-        if (check4) {
-            check4();
-        }
+        checkIfNecessary();
 
         if (!historyState.isEmpty()) {
             fileModel.setSaved(false);
@@ -910,19 +873,7 @@ public class CreasePattern_Worker {
             if (!foldLineSet.fix1()) break;
         }
         //foldLineSet.addsenbun  delsenbunを実施しているところでcheckを実施
-        if (check1) {
-            check1();
-        }
-        if (check2) {
-            check2();
-        }
-        if (check3) {
-            check3();
-        }
-        if (check4) {
-            check4();
-        }
-
+        checkIfNecessary();
     }
 
     public void set_i_check1(boolean i) {
@@ -934,23 +885,16 @@ public class CreasePattern_Worker {
     }
 
     public void fix2() {
-        while (true) {
-            if (!foldLineSet.fix2()) break;
-        }
+        foldLineSet.fix2();
         //foldLineSet.addsenbun  delsenbunを実施しているところでcheckを実施
-        if (check1) {
-            check1();
-        }
-        if (check2) {
-            check2();
-        }
-        if (check3) {
-            check3();
-        }
-        if (check4) {
-            check4();
-        }
+        checkIfNecessary();
+    }
 
+    private void checkIfNecessary() {
+        if (check1) check1();
+        if (check2) check2();
+        if (check3) check3();
+        if (check4) check4();
     }
 
     public void setCheck2(boolean i) {


### PR DESCRIPTION
Unnecessary checks are removed in toggleMV action, and QuadTree is applied to cAMV. Now cAMV is roughly 100x faster for Ryujin-sized CP.

This PR also fixed a critical bug in the CombinationGenerator that could lead to the searching getting stuck in a situation that actually is impossible but still trying forever to find a solution.